### PR TITLE
project overview

### DIFF
--- a/Assignments/project-overview.md
+++ b/Assignments/project-overview.md
@@ -1,0 +1,105 @@
+---
+layout: page
+title: Project Overview
+permalink: /assignments/project-overview
+parent: Assignments
+nav_order: 3
+---
+
+# Project Overview
+The individual and team project for this class are designed to mirror the experiences of a software engineer joining a new development team:
+you will be "onboarded" to our codebase, make several individual contributions, and then form a team to propose, develop and implement new features.
+The codebase that we'll be developing on is a Fake Stack Overflow project (let's call it HuskyFlow). You will get an opportunity to work with the starter code which provides basic skeleton for the app and then additional features will be proposed and implemented by you!
+All implementation will take place in the TypeScript programming language, using React for the user interface.
+
+### Overview of Project Deliverables
+
+| Date | Deliverable | Description | 
+| -----| ----------- | ----------- |
+| 01/29/2025| Team Formation Survey | Specify preferences for teammates |
+| 02/03/2025| Project Kick-off Meeting | Schedule a meeting with your Mentor TA during this week |
+| 02/12/2025 | Preliminary Project Plan | Propose a new feature for StackOverflow project that can be planned and implemented within 7 weeks |
+| 02/26/2025 | Revised Project Plan | Refine the scope of your feature based on staff feedback, define detailed requirements and project acceptance criteria. |
+| 04/09/2025 | Project Delivery - Implementation and Documentation | Deliver/Deploy your new features, including design documentation and tests |
+
+### Summary of Project Grading
+Your overall project grade (which will account for 40% of your final grade in this course) will be the weighted average of each of the deliverables.
+
+* Planning (20%)
+  * This includes the Preliminary Project Plan and the Revised Project Plan.
+* Process (20%)
+  * This includes: use of a structured development process, including regular git commits, pull requests, code reviews, timely completion of progress reports and individual/team surveys, and weekly meetings with TA Mentor.
+  * This also includes appropriate division of labor within the project (i.e., roughly equal). For full credit, each member of the team must have at least 2 commits during the each sprint.
+* Product (40%)
+  * 20% Successful delivery of your Minimum Viable Product as defined in your project plan
+  * 10% Desirable delivered features
+  * 10% Test suite of your features.
+* Reports (20%)
+  * 10% Final Report
+  * 10% Poster and Demo
+* Individual Reflection (required to receive an ‘A’)
+  
+In cases where team members do not equally contribute to the project, we may assign different grades to different individuals, up to an extreme of deducting 50% of the team project grade for a student (which might arise to 100% deduction for not contributing to the project at all).
+We will evaluate each individual's contribution on the basis of a variety of factors, including progress reports at weekly meetings, through inspecting version control history, through each students' self-reflection, and through each students' peer evaluations (during and/or at the end of the project).
+We will make regular efforts to collect and distribute this feedback throughout the project — our ultimate goal is for all students to participate and receive full marks.
+
+### Team Formation
+All projects will be completed in a team of 3-4 students.
+The very first deliverable for the project will be a self assessment and team preference survey: you will be able to indicate
+your preferences for teammates. The instructors will assign students to the teams based on a number of factors including your responses to the survey and diversity of skills for the teammates.
+All students in each team MUST be in the same section of the class.
+
+
+### Team Meetings with TA Mentor
+Each team will be assigned a TA to act as a mentor, who will work closely with you for the entire project and also will serve as your point of contact for project questions and grading. 
+
+During Week 5, you will arrange a "Kickoff Meeting" with your TA mentor, where you will meet your TA mentor and have the opportunity to share any early ideas that you might want feedback on before submitting the your preliminary project plan.
+
+Once project begins in full force, you will have weekly meetings with your TA mentor (scheduled at your team's and the TA's convenience) in order to help ensure that you are making progress on the project, and to help address problems that you encounter (be they technical or non-technical problems). Weekly meetings will often include review of your pull requests, github commits,  code reviews and demos from each group.
+
+
+###  Preliminary Project Plan
+All projects will involve frontend and backend development of new features for FakeStackoverflow.
+Once teams have been formed, you and your team will decide what kind of new features you would like to build.
+Your features should be something that can be implemented within the timeframe allotted (5-7 weeks), and will be implemented in a fork of the main codebase.
+Given that you will be up-to-speed on the project codebase (and have been introduced to TypeScript, React, NodeJS, and testing frameworks),
+and that you will have a team of three or four, we expect that the feature that you propose will be more complex than the feature implemented in the individual projects.
+
+The project plan will focus on two sections:
+* User stories and conditions of satisfaction that describe the features that you plan to implement. **EACH CONDITION OF SATISFACTION MUST HAVE A PRIORITY (Essential, Desirable, or Optional)**. The set of essential items will constitute the "Minimum Viable Product" discussed above.
+* Work breakdown: Map your user stories to engineering tasks. Assign each task to a team member (or pair of team members), provide an estimate for how long each task will take, a brief rationale for that estimate, and schedule those stories into sprints.
+
+### Creating a GitHub Repository
+Your team's development must take place within a GitHub repository in our GitHub Classroom. This repository will be private, and visible only to your team and the course staff. After the semester ends, you are welcome to make it public - you will have complete administrative control of the repository.
+
+We will provide instructions to set up these repositories for all groups and will also provide the starter code for the project (after the revised project plans are submitted).
+
+### Revised Project Plan
+Based on the feedback that you receive from the course staff, you will revise your preliminary project plan, creating a more detailed plan to implement your new feature.
+
+The project plan will include:
+* Revised user stories and conditions of satisfaction (based on feedback on the preliminary project plan)
+* Revised work breakdown (based on feedback on the preliminary project plan)
+
+Your team will self-organize, as agile teams do, and will use the work breakdown and schedule as the basis for weekly check-ins with your team's TA.
+
+### Software Development Process
+Each team is expected to use of a structured development process, including use of pull requests and code reviews for their regular github commits. You will also need to ensure appropriate division of labor within the project (i.e., roughly equal). Teams will also be expected to complete regular progress reports (or sprint retrospectives), and provide honest feedback as part of individual/team surveys. Peer evaluations will also be used (for Week 6, 8, 10-14). 
+Please note that one of the most important factors in successfully completing a team project is having open, honest and effective communication between all team members as well as stakeholders. 
+
+### Project Implementation and Documentation
+
+Your final team deliverable will be a "release" of your new feature on GitHub (with tests), and will be accompanied by a demo.
+
+Your final team deliverable will include:
+* The implementation of your new features
+* Automated tests for your new features
+* A Final Report
+* A Poster & Demo (each instructor will provide specifics of the demo, which might vary for each section)
+    
+Accompanying the final team deliverable will be an *individual reflection*, which every student must submit on their own, which will include your reflections on:
+* The evolution of your project concept: How does the project that you delivered compare to what you originally planned to deliver? What caused these deviations?
+* The software engineering processes that you feel could have been improved in your project: were there any procesess that in hindsight, you wish that you followed, or wish that you followed better?
+* Your team dynamic: Provide a frank (and ideally, blameless) postmortem of your and your teammates collaborative performance and participation. If you had to do this same project over with the same teammates, what would *you* have done differently (or not) to improve your team's overall performance?
+
+The details for the final project deliverable and associated rubrics will be released by Week 10.

--- a/Assignments/project-overview.md
+++ b/Assignments/project-overview.md
@@ -66,7 +66,7 @@ Given that you will be up-to-speed on the project codebase (and have been introd
 and that you will have a team of three or four, we expect that the feature that you propose will be more complex than the feature implemented in the individual projects.
 
 The project plan will focus on two sections:
-* User stories and conditions of satisfaction that describe the features that you plan to implement. **EACH CONDITION OF SATISFACTION MUST HAVE A PRIORITY (Essential, Desirable, or Optional)**. The set of essential items will constitute the "Minimum Viable Product" discussed above.
+* User stories and conditions of satisfaction that describe the features that you plan to implement. **EACH CONDITION OF SATISFACTION MUST HAVE A PRIORITY (Essential, Desirable, or Extension)**. The set of essential items will constitute the "Minimum Viable Product" discussed above.
 * Work breakdown: Map your user stories to engineering tasks. Assign each task to a team member (or pair of team members), provide an estimate for how long each task will take, a brief rationale for that estimate, and schedule those stories into sprints.
 
 ### Creating a GitHub Repository


### PR DESCRIPTION
updated project overview
-updated dates
-added a word about weekly meetings including review of PRs, commits, reviews, demos, etc.
-changed "4 commits per project" to "2 commits per sprint".

Question:
Should we updated the grading breakdown?
Revised project plan is often a copy-paste of preliminary plan. Perhaps we can make that worth 5% and shift that grade somewhere else!