### PR TITLE
added tsc init command befpre the ts-node step

### DIFF
--- a/tutorials/week1-getting-started.md
+++ b/tutorials/week1-getting-started.md
@@ -207,7 +207,11 @@ Typescript is a superscript of JavaScript which adds type information and other 
 
 - This will install Typescript locally in the current directory.
 
-6. Run the command `npx ts-node hello-world.ts`.
+6. Initialize a tsconfig.json file by running the command `npx tsc --init` .
+
+- This generates a tsconfig.json file with default TypeScript compiler options, which you can customize later if needed.
+
+7. Run the command `npx ts-node hello-world.ts`.
 
 - If you are prompted, enter `y`.
 - This will give the result below.


### PR DESCRIPTION
Earlier, the npx node-ts step was failing with error:

SyntaxError: Unexpected token 'export' , because the tsconfig.json was not getting generated.

The fix is to run the npx tsc --init command before the npx ts-node command.

TLDR: adde npx tsc --init to generate tsconfig.json